### PR TITLE
Update AddFridge nav route and add CameraScreen

### DIFF
--- a/app/src/main/java/com/example/fridgemate/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/fridgemate/components/BottomNavigationBar.kt
@@ -18,7 +18,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 sealed class BottomNavItem(val route: String, val icon: ImageVector, val label: String) {
     object Home : BottomNavItem("home", Icons.Default.Home, "ホーム")
     object Search : BottomNavItem("search", Icons.Default.Search, "検索")
-    object AddFridge : BottomNavItem("search", Icons.Default.AddCircle, "追加")
+    object AddFridge : BottomNavItem("CameraScreen", Icons.Default.AddCircle, "追加")
     object List : BottomNavItem("shopping", Icons.Default.List, "リスト")
     object Config : BottomNavItem("shopping", Icons.Default.Settings, "設定")
 }

--- a/app/src/main/java/com/example/fridgemate/components/Navigation.kt
+++ b/app/src/main/java/com/example/fridgemate/components/Navigation.kt
@@ -11,6 +11,7 @@ import com.example.fridgemate.ui.RecipeListScreen
 import com.example.fridgemate.ui.RecipeDetailScreen
 import com.example.fridgemate.ui.InventoryScreen
 import com.example.fridgemate.ui.ExpiryScreen
+import com.example.fridgemate.ui.CameraScreen
 
 
 @Composable
@@ -24,6 +25,9 @@ fun FridgeMateNavGraph(navController: NavHostController) {
         }
         composable("search") {
             SearchScreen(navController = navController)
+        }
+        composable("CameraScreen") {
+            CameraScreen(navController = navController)
         }
         composable("shopping") {
             ShoppingListScreen(navController = navController)


### PR DESCRIPTION
Changed AddFridge BottomNavItem route from 'search' to 'CameraScreen' and registered CameraScreen in the navigation graph. This enables navigation to the CameraScreen from the bottom navigation bar.