### PR TITLE
Add recipe API integration and HomeViewModel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,4 +67,6 @@ dependencies {
     //http
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.google.accompanist:accompanist-permissions:0.34.0")
+    // 画像表示用
+    implementation("io.coil-kt:coil-compose:2.4.0")
 }

--- a/app/src/main/java/com/example/fridgemate/api/ImageUploader.kt
+++ b/app/src/main/java/com/example/fridgemate/api/ImageUploader.kt
@@ -11,8 +11,8 @@ import java.io.IOException
 object ImageUploader {
 
     private const val TAG = "ImageUploader"
-//    private const val SERVER_URL = "http://192.168.50.77:5000/ocr"
-    private const val SERVER_URL = "http://192.168.11.16:5000/test_ocr"
+    //private const val SERVER_URL = "http://192.168.50.77:5000/ocr"
+    private const val SERVER_URL = "http://192.168.50.77:5000/test_ocr"
     fun sendImageToServer(imageFile: File, onResult: (String?) -> Unit) {
         val client = OkHttpClient()
 

--- a/app/src/main/java/com/example/fridgemate/api/RecipeApi.kt
+++ b/app/src/main/java/com/example/fridgemate/api/RecipeApi.kt
@@ -1,0 +1,52 @@
+package com.example.fridgemate.api
+
+import android.util.Log
+import okhttp3.*
+import org.json.JSONObject
+import java.io.IOException
+import kotlin.math.log
+
+data class RecipeItem(
+    val title: String,
+    val imageUrl: String,
+    val recipeUrl: String
+)
+
+object RecipeApi {
+    private const val BASE_URL =
+        "https://app.rakuten.co.jp/services/api/Recipe/CategoryRanking/20170426"
+    private const val APP_ID = "1081684173276999312" // ← 自分のキーに差し替える
+
+    private val client = OkHttpClient()
+
+    fun fetchRecipes(onResult: (List<RecipeItem>) -> Unit) {
+        val url = "$BASE_URL?applicationId=$APP_ID"
+
+        val request = Request.Builder().url(url).build()
+
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                onResult(emptyList())
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                val result = mutableListOf<RecipeItem>()
+
+                val json = JSONObject(response.body?.string() ?: "")
+                val recipes = json.getJSONArray("result")
+                Log.e(String.toString(), "APIレスポンス: ${recipes ?: "null"}")
+                for (i in 0 until recipes.length()) {
+                    val item = recipes.getJSONObject(i)
+                    result.add(
+                        RecipeItem(
+                            title = item.getString("recipeTitle"),
+                            imageUrl = item.getString("foodImageUrl"),
+                            recipeUrl = item.getString("recipeUrl")
+                        )
+                    )
+                }
+                onResult(result)
+            }
+        })
+    }
+}

--- a/app/src/main/java/com/example/fridgemate/api/TextFilterApi.kt
+++ b/app/src/main/java/com/example/fridgemate/api/TextFilterApi.kt
@@ -14,7 +14,7 @@ object TextFilterApi {
 
     // FlaskサーバーのIPアドレスとポート（実機と同じネットワークにいる前提）
     //private const val SERVER_URL = "http://192.168.50.77:5000/filter_text"
-    private const val SERVER_URL = "http://192.168.11.16:5000/test_filter"
+    private const val SERVER_URL = "http://192.168.50.77:5000/test_filter"
 
     private val client = OkHttpClient()
 

--- a/app/src/main/java/com/example/fridgemate/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/fridgemate/components/BottomNavigationBar.kt
@@ -29,8 +29,9 @@ val bottomNavItems = listOf(
     BottomNavItem.Search,
     BottomNavItem.AddFridge,
     //BottomNavItem.List,
-    BottomNavItem.Config,
-    BottomNavItem.InvScreen
+    BottomNavItem.InvScreen,
+    BottomNavItem.Config
+
 )
 
 @Composable

--- a/app/src/main/java/com/example/fridgemate/ui/EditFoodScreen.kt
+++ b/app/src/main/java/com/example/fridgemate/ui/EditFoodScreen.kt
@@ -31,7 +31,11 @@ fun EditFoodScreen(
     fridgeViewModel: FridgeViewModel,
     modifier: Modifier = Modifier
 ) {
-    val tempItems = fridgeViewModel.tempFoodItems
+    val tempItems = remember { mutableStateListOf<String>() }
+    LaunchedEffect(Unit) {
+        tempItems.clear()
+        tempItems.addAll(fridgeViewModel.tempFoodItems)
+    }
 
     Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
         Text("ViewModelの中身: ${tempItems.joinToString()}", style = MaterialTheme.typography.bodySmall)
@@ -61,7 +65,7 @@ fun EditFoodScreen(
                 val json = JSONArray(tempItems).toString()
                 val requestBody = json.toRequestBody("application/json".toMediaTypeOrNull())
                 val request = Request.Builder()
-                    .url("http://192.168.11.16:5000/add_food_items")
+                    .url("http://192.168.50.77:5000/add_food_items")
                     .post(requestBody)
                     .build()
                 client.newCall(request).enqueue(object : Callback {

--- a/app/src/main/java/com/example/fridgemate/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/fridgemate/ui/HomeScreen.kt
@@ -13,11 +13,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import coil.compose.AsyncImage
 import com.example.fridgemate.components.BottomNavigationBar
-
+import com.example.fridgemate.viewmodel.FridgeViewModel
+import com.example.fridgemate.viewmodel.HomeViewModel
 @Composable
-fun HomeScreen(navController: NavController) {
+fun HomeScreen(navController: NavController,fridgeViewModel: FridgeViewModel = viewModel()) {
+    //
+    val homeViewModel: HomeViewModel = viewModel<HomeViewModel>()
+    val recipes = homeViewModel.recipes
     Scaffold(
         //bottomBar = { BottomNavigationBar(navController = navController) }
     ) { innerPadding ->
@@ -50,39 +56,25 @@ fun HomeScreen(navController: NavController) {
                 style = MaterialTheme.typography.titleMedium
             )
 
-            Surface(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-                shape = RoundedCornerShape(12.dp),
-                tonalElevation = 2.dp
-            ) {
-                Column(
-                    modifier = Modifier.padding(16.dp)
-                ) {
-                    Box(
+            LazyRow {
+                items(recipes.size) { i ->
+                    val item = recipes[i]
+                    Surface(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .height(160.dp)
+                            .width(200.dp)
+                            .padding(end = 8.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        tonalElevation = 2.dp
                     ) {
-                        Text(
-                            text = "画像",
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text("しょうが焼き", fontWeight = FontWeight.SemiBold)
-                    Text("10分", style = MaterialTheme.typography.bodySmall)
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Row {
-                        repeat(3) {
-                            Box(
+                        Column(Modifier.padding(12.dp)) {
+                            AsyncImage(  // Coilライブラリ必要
+                                model = item.imageUrl,
+                                contentDescription = item.title,
                                 modifier = Modifier
-                                    .size(32.dp)
-                                    .padding(end = 4.dp)
-                            ) {
-                                Text("🥕", modifier = Modifier.align(Alignment.Center))
-                            }
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                            )
+                            Text(item.title, fontWeight = FontWeight.Bold)
                         }
                     }
                 }

--- a/app/src/main/java/com/example/fridgemate/ui/InventoryScreen.kt
+++ b/app/src/main/java/com/example/fridgemate/ui/InventoryScreen.kt
@@ -27,7 +27,7 @@ fun InventoryScreen(navController: NavController) {
     LaunchedEffect(Unit) {
         val client = OkHttpClient()
         val request = Request.Builder()
-            .url("http://192.168.11.16:5000/get_food_items") // エミュレータの場合
+            .url("http://192.168.50.77:5000/get_food_items") // エミュレータの場合
             .build()
         client.newCall(request).enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {

--- a/app/src/main/java/com/example/fridgemate/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/fridgemate/viewmodel/HomeViewModel.kt
@@ -1,0 +1,22 @@
+package com.example.fridgemate.viewmodel
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.lifecycle.ViewModel
+import com.example.fridgemate.api.RecipeApi
+import com.example.fridgemate.api.RecipeItem
+
+class HomeViewModel : ViewModel() {
+    private val _recipes = mutableStateListOf<RecipeItem>()
+    val recipes: List<RecipeItem> get() = _recipes
+
+    init {
+        loadRecipes()
+    }
+
+    private fun loadRecipes() {
+        RecipeApi.fetchRecipes { items ->
+            _recipes.clear()
+            _recipes.addAll(items)
+        }
+    }
+}


### PR DESCRIPTION
Introduces RecipeApi for fetching recipes from Rakuten API and HomeViewModel to manage recipe state. Updates HomeScreen to display recipes using Coil for image loading. Changes server URLs in API and UI files to use a consistent IP address. Minor adjustment to bottom navigation item order.